### PR TITLE
[FIX] removes unnecessary implicitly unwrapped Optional

### DIFF
--- a/Sources/UIWindowTransitions/UIWindowTransitions.swift
+++ b/Sources/UIWindowTransitions/UIWindowTransitions.swift
@@ -28,7 +28,7 @@ public extension UIWindow {
 			
 			/// Return the media timing function associated with curve
 			internal var function: CAMediaTimingFunction {
-				let key: String!
+				let key: String
 				switch self {
 				case .linear:		key = kCAMediaTimingFunctionLinear
 				case .easeIn:		key = kCAMediaTimingFunctionEaseIn


### PR DESCRIPTION
### Background
Since you always initialize `key` with a value, there is no need to use an implicitly unwrapped `Optional<String>` here. 